### PR TITLE
Add data privacy link to the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,10 @@
       <nav class="p-footer__nav" role="navigation">
         <ul class="p-footer__links">
           <li class="p-footer__item">
-              <a class="p-footer__link" href="http://www.ubuntu.com/legal"><small>Legal information</small></a>
+              <a class="p-footer__link" href="https://www.ubuntu.com/legal"><small>Legal information</small></a>
+          </li>
+          <li class="p-footer__item">
+              <a class="p-footer__link" href="https://www.ubuntu.com/legal/data-privacy"><small>Data privacy</small></a>
           </li>
           <li class="p-footer__item">
             <a class="p-footer__link" href="https://github.com/canonical-web-and-design/design.ubuntu.com/issues/new"><small>Report a bug on this site</small></a>


### PR DESCRIPTION
## Done

- Add a data privacy link to the footer

## QA

- Run the site
- See there is a link to https://www.ubuntu.com/legal/data-privacy in the footer

