### PR TITLE
1141: update font download links to assets that include ubuntu thin

### DIFF
--- a/font/index.md
+++ b/font/index.md
@@ -153,13 +153,13 @@ Greek sample:
     <div class="col-8">
       <h2>Resources</h2>
       <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/fad7939b-ubuntu-font-family-0.83.zip" class="p-link--external">Download the Ubuntu Font Family</a> (2.0MB)</li>
-        <li class="p-list__item"><p><a href="https://assets.ubuntu.com/v1/4cd05122-ubuntu-font-family-sources_0.83.orig.tar.gz" class="p-link--external">Download the Ubuntu Font Family source code</a></p> (For font designers with a copy of Font Lab Studio, 7.8MB)</li>
+        <li class="p-list__item"><a href="https://assets.ubuntu.com/v1/0cef8205-ubuntu-font-family-0.83.zip" class="p-link--external">Download the Ubuntu Font Family</a> (2.2MB)</li>
+        <li class="p-list__item"><p><a href="https://assets.ubuntu.com/v1/0f5898c1-ubuntu-font-family-sources_0.83.orig.tar.gz" class="p-link--external">Download the Ubuntu Font Family source code</a></p> (For font designers with a copy of Font Lab Studio, 8.4MB)</li>
         <li class="p-list__item"><a href="https://fonts.google.com/?query=Ubuntu" class="p-link--external">Google Web Fonts</a></li>
         <li class="p-list__item"><a href="http://launchpad.net/ubuntu-font-family" class="p-link--external">Launchpad</a></li>
         <li class="p-list__item"><a href="http://wiki.ubuntu.com/Ubuntu_Font_Family" class="p-link--external">Wiki documentation</a></li>
       </ul>
-      <p><a href="https://assets.ubuntu.com/v1/fad7939b-ubuntu-font-family-0.83.zip" class="p-button--brand">Download for free</a></p>
+      <p><a href="https://assets.ubuntu.com/v1/0cef8205-ubuntu-font-family-0.83.zip" class="p-button--brand">Download for free</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Updated font download links to point to new versions of the zip file, which now includes Ubuntu thin

## QA

- Check out this feature branch
- Run the site using the command ./run serve
- View the site locally in your web browser at: [/font](http://0.0.0.0:8011/font)
- In the resources section at the bottom of the page, click "Download the Ubuntu Font Family", "Download the Ubuntu Font Family source code" and the orange "Download for free" CTA, and ensure all three files contain `Ubuntu-Th.ttf`

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1141
