### PR TITLE
Revert to ruby 2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Build stage: Install ruby dependencies
 # ===
-FROM ruby:2.7 AS build-site
+FROM ruby:2.5 AS build-site
 WORKDIR /srv
 ADD . .
 RUN bundle install

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
+    "docker:disable",
     "schedule:monthly",
     "group:all"
   ],


### PR DESCRIPTION
## Done

Downgrade to ruby 2.5
Disable renovate in docker

## QA

- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag design.ubuntu.com .`
- `docker run -ti -p "8006:80" --env SECRET_KEY=secret_key design.ubuntu.com`
- http://localhost:8006 play around