### PR TITLE
Add rewrite rule for legal fonts

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -22,6 +22,7 @@ server {
     # Redirects
     rewrite ^/apps(.*) https://docs.ubuntu.com/phone/en/apps/index permanent;
     rewrite ^/scopes(.*) https://docs.ubuntu.com/phone/en/scopes/index permanent;
+    rewrite ^/font/ufl(.*) https://ubuntu.com/legal/font-licence permanent;
 
     # Remove index or index.html from URIs
     if ($request_uri ~ ^.*/index(.html)?$) {


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-web-and-design/design.ubuntu.com/issues/158

## QA
- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag design.ubuntu.com .`
- `docker run -ti -p "8006:80" --env SECRET_KEY=secret_key design.ubuntu.com`
- Make sure that `http://localhost:8006/font/ufl` redirects to https://ubuntu.com/legal/font-licence