### PR TITLE
Fix file size/typo

### DIFF
--- a/_data/downloads.yaml
+++ b/_data/downloads.yaml
@@ -92,7 +92,7 @@
 
 - download: https://assets.ubuntu.com/v1/a2d22e73-premier-cloud-partner-logo-set.zip
   image: https://assets.ubuntu.com/v1/059e5877-premier_cloud_partner_hex.png
-  name: Premier cloud partner logo set (555 MB)
+  name: Premier cloud partner logo set (555 KB)
 
 - download: https://assets.ubuntu.com/v1/fbd83df1-certified-cloud-partner-logo-set.zip
   image: https://assets.ubuntu.com/v1/9822313a-certified_cloud_partner_hex.png


### PR DESCRIPTION
## Done

Change the download size for *Premier cloud partner logo set* file because it appears to be far more smaller than what was originally listed on the website

## QA

1. Start the site
2. Navigate to http://localhost:8001/downloads/
3. Scroll down until *Premier cloud partner logo set*
4. A new, fixed, file size should appear, and not something like this:
![Premier cloud partner logo set](https://i.imgur.com/RaggPJ6.png)

## Issue / Card

N/A. I originally wanted to make an issue but then I decided to just modify the problematic file and then make this pull request
