### PR TITLE
Bump cookie policy to v3.03

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@canonical/global-nav": "2.4.3",
-    "@canonical/cookie-policy": "3.0.2",
+    "@canonical/cookie-policy": "3.0.3",
     "postcss": "8.1.1",
     "vanilla-framework": "2.17.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@canonical/cookie-policy@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.2.tgz#5a6a3d5f02c2fc139e38749e25e14254d4b3cdd8"
-  integrity sha512-xe25hHA9jrfgWTs+pVjO4UL/INnM1Pp0ukYgolMYTc+kwSguAmnXXDN3vhoSOToS6DPU5E6yh7U/wQqXVqos7g==
+"@canonical/cookie-policy@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.3.tgz#77ff09de8cc91c3bd12d23bfeaaf23a0206995ad"
+  integrity sha512-cTNrBAO+w5Akrn32Arkp/YGgT9KXTUuCMAgE8ipABBtkEIQ2Z708mTkZ3FNgefxPvMuDuLCVvKhvHik31SEShg==
 
 "@canonical/global-nav@2.4.3":
   version "2.4.3"


### PR DESCRIPTION
## Done

- Bump cookie policy to v3.03
- Update GTM to track initial pageview

## QA

1. Check out this feature branch
2. Run the site using the command ./run serve
3. View the site locally in your web browser at: http://0.0.0.0:8011
4. See that you are using cookie policy 3.03
