### PR TITLE
remove unused argument from globalNav init

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -44,9 +44,7 @@
 <script src="/assets/js/cookie-policy.js"></script>
 <script src="/assets/js/global-nav.js"></script>
 <script>
-  canonicalGlobalNav.createNav({
-    maxWidth: '72rem',
-  });
+  canonicalGlobalNav.createNav();
   cpNs.cookiePolicy();
 </script>
 


### PR DESCRIPTION
## Done

Removed redundant argument from globalNav initialiser call.

## QA

- Visit https://design-ubuntu-com-240.demos.haus/
- See that the "All Canonical" item is present in the nav, and the dropdown works
